### PR TITLE
[Cron] Change timezone of the cron runner

### DIFF
--- a/src/cron/cron.service.ts
+++ b/src/cron/cron.service.ts
@@ -23,7 +23,10 @@ export class CronService implements OnModuleInit {
     );
   }
   // Run every day at 8 PM local time (20:00)
-  @Cron('0 20 * * *')
+  @Cron('0 20 * * *', {
+    name: 'timeoutUsersDaily',
+    timeZone: 'Asia/Manila',
+  })
   async timeoutUsersDaily() {
     try {
       const result = await this.usersService.timeoutAllActiveUsers();


### PR DESCRIPTION
This pull request updates the `CronService` in the `src/cron/cron.service.ts` file to enhance the configuration of the `timeoutUsersDaily` cron job. The most important change is the addition of a name and timezone to the cron job configuration.

Improvements to cron job configuration:

* [`src/cron/cron.service.ts`](diffhunk://#diff-c18c1daa9d1e2493a2b92cec33b01be231319467e4a19bc9436a154f9cd33a87L26-R29): Updated the `@Cron` decorator for the `timeoutUsersDaily` method to include a `name` property (`timeoutUsersDaily`) and a `timeZone` property (`Asia/Manila`) for better identification and timezone specificity.…timeout job